### PR TITLE
remove secret from folder

### DIFF
--- a/src/actions/AppUIActions.js
+++ b/src/actions/AppUIActions.js
@@ -30,7 +30,12 @@ class AppUIActions {
   loginUser({ username, password }) {
     secretin
       .loginUser(username, password)
-      .then(currentUser => this.loginUserSuccess({ currentUser }))
+      .then(currentUser => (
+        this.loginUserSuccess({
+          currentUser,
+          metadata: currentUser.metadatas,
+        })
+      ))
       .catch((error) => {
         if (error.match && error.match(/user not found/i)) {
           return this.loginUserFailure({

--- a/src/actions/MetadataActions.js
+++ b/src/actions/MetadataActions.js
@@ -6,14 +6,19 @@ class MetadataActions {
     this.generateActions(
       'createSecretSuccess',
       'deleteSecretSuccess',
+      'deleteSecretFailure',
       'createSecretUserRightsSuccess',
       'createSecretUserRightsFailure',
       'updateSecretUserRightsSuccess',
       'updateSecretUserRightsFailure',
       'deleteSecretUserRightsSuccess',
       'deleteSecretUserRightsFailure',
+      'removeSecretFromCurrentFolderSuccess',
+      'removeSecretFromCurrentFolderFailure',
       'moveSecretToFolderSuccess',
       'moveSecretToFolderFailure',
+      'addSecretToFolderSuccess',
+      'addSecretToFolderFailure',
     );
   }
 
@@ -43,6 +48,9 @@ class MetadataActions {
     return secretin
       .deleteSecret(secret.id)
       .catch((error) => {
+        this.deleteSecretFailure({
+          currentUser: secretin.currentUser,
+        });
         throw error;
       })
       .then(() => (
@@ -88,21 +96,60 @@ class MetadataActions {
       });
   }
 
-  moveSecretToFolder({ secret, folder }) {
+  addSecretToFolder({ secret, folder }) {
     return secretin
       .addSecretToFolder(secret.id, folder.id)
       .then(() => (
-        this.moveSecretToFolderSuccess({
+        this.addSecretToFolderSuccess({
           secret,
           folder,
           metadata: secretin.currentUser.metadatas,
         })
       ))
       .catch((error) => {
-        this.moveSecretToFolderFailure({ error });
+        this.addSecretToFolderFailure({ error });
         throw error;
       });
   }
+
+  removeSecretFromCurrentFolder({ secret, currentFolderId }) {
+    return secretin
+      .removeSecretFromFolder(secret.id, currentFolderId)
+      .then(() => (
+        this.removeSecretFromCurrentFolderSuccess({
+          secret,
+          currentFolderId,
+          metadata: secretin.currentUser.metadatas,
+        })
+      ))
+      .catch((error) => {
+        this.removeSecretFromCurrentFolderFailure({ error });
+        throw error;
+      });
+  }
+
+  // moveSecretToFolder({ secret, fromFolder, toFolder }) {
+  //   return secretin
+  //     .removeSecretFromFolder(secret.id, fromFolder.id)
+  //     .then(() => {
+  //       if (toFolder !== 'ROOT') {
+  //         return secretin.addSecretToFolder(secret.id, toFolder.id);
+  //       }
+  //       return new Promise();
+  //     })
+  //     .then(() => (
+  //       this.moveSecretToFolderSuccess({
+  //         secret,
+  //         fromFolder,
+  //         toFolder,
+  //         metadata: secretin.currentUser.metadatas,
+  //       })
+  //     ))
+  //     .catch((error) => {
+  //       this.moveSecretToFolderFailure({ error });
+  //       throw error;
+  //     });
+  // }
 }
 
 export default alt.createActions(MetadataActions);

--- a/src/actions/MetadataActions.js
+++ b/src/actions/MetadataActions.js
@@ -5,6 +5,7 @@ class MetadataActions {
   constructor() {
     this.generateActions(
       'createSecretSuccess',
+      'createSecretFailure',
       'deleteSecretSuccess',
       'deleteSecretFailure',
       'createSecretUserRightsSuccess',
@@ -15,8 +16,6 @@ class MetadataActions {
       'deleteSecretUserRightsFailure',
       'removeSecretFromCurrentFolderSuccess',
       'removeSecretFromCurrentFolderFailure',
-      'moveSecretToFolderSuccess',
-      'moveSecretToFolderFailure',
       'addSecretToFolderSuccess',
       'addSecretToFolderFailure',
     );
@@ -39,9 +38,13 @@ class MetadataActions {
       })
       .then(() => (
         this.createSecretSuccess({
-          currentUser: secretin.currentUser,
+          metadata: secretin.currentUser.metadatas,
         })
-      ));
+      ))
+      .catch((error) => {
+        this.createSecretFailure({ error });
+        throw error;
+      });
   }
 
   deleteSecret({ secret }) {
@@ -49,13 +52,13 @@ class MetadataActions {
       .deleteSecret(secret.id)
       .catch((error) => {
         this.deleteSecretFailure({
-          currentUser: secretin.currentUser,
+          metadata: secretin.currentUser.metadatas,
         });
         throw error;
       })
       .then(() => (
         this.deleteSecretSuccess({
-          currentUser: secretin.currentUser,
+          metadata: secretin.currentUser.metadatas,
         })
       ));
   }
@@ -127,29 +130,6 @@ class MetadataActions {
         throw error;
       });
   }
-
-  // moveSecretToFolder({ secret, fromFolder, toFolder }) {
-  //   return secretin
-  //     .removeSecretFromFolder(secret.id, fromFolder.id)
-  //     .then(() => {
-  //       if (toFolder !== 'ROOT') {
-  //         return secretin.addSecretToFolder(secret.id, toFolder.id);
-  //       }
-  //       return new Promise();
-  //     })
-  //     .then(() => (
-  //       this.moveSecretToFolderSuccess({
-  //         secret,
-  //         fromFolder,
-  //         toFolder,
-  //         metadata: secretin.currentUser.metadatas,
-  //       })
-  //     ))
-  //     .catch((error) => {
-  //       this.moveSecretToFolderFailure({ error });
-  //       throw error;
-  //     });
-  // }
 }
 
 export default alt.createActions(MetadataActions);

--- a/src/components/secrets/SecretListItem/Actions.js
+++ b/src/components/secrets/SecretListItem/Actions.js
@@ -9,11 +9,11 @@ import Icon from 'components/utilities/Icon';
 
 const propTypes = {
   secret: PropTypes.any,
+  parentFolderId: PropTypes.string,
 };
 
-function SecretListItemActions({ secret }) {
+function SecretListItemActions({ parentFolderId, secret }) {
   const currentUser = AppUIStore.getCurrentUser();
-
   return (
     <Dropdown id="secret-action" pullRight>
       <Dropdown.Toggle>
@@ -33,6 +33,16 @@ function SecretListItemActions({ secret }) {
         </Dropdown.MenuItem>
 
         <Dropdown.MenuItem divider />
+
+        <Dropdown.MenuItem
+          onSelect={() => MetadataActions.removeSecretFromCurrentFolder({
+            secret,
+            currentFolderId: parentFolderId,
+          })}
+          disabled={!secret.canBeUpdatedBy(currentUser) || typeof parentFolderId === 'undefined'}
+        >
+          Remove from this folder
+        </Dropdown.MenuItem>
 
         <Dropdown.MenuItem
           onSelect={() => MetadataActions.deleteSecret({ secret })}

--- a/src/components/secrets/SecretListItem/Folder.js
+++ b/src/components/secrets/SecretListItem/Folder.js
@@ -11,7 +11,7 @@ import AppUIStore from 'stores/AppUIStore';
 import UserAvatars from 'components/users/UserAvatars';
 import Icon from 'components/utilities/Icon';
 
-import SecretListItemActions from './Actions';
+import SecretListItemOptions from './Options';
 
 const propTypes = {
   secret: PropTypes.any,
@@ -64,7 +64,7 @@ function SecretListItemFolder(props) {
           }
         </td>
         <td className="secret-list-item-last-actions">
-          <SecretListItemActions parentFolderId={folders.last()} secret={secret} />
+          <SecretListItemOptions parentFolderId={folders.last()} secret={secret} />
         </td>
       </tr>
     )

--- a/src/components/secrets/SecretListItem/Folder.js
+++ b/src/components/secrets/SecretListItem/Folder.js
@@ -11,7 +11,7 @@ import AppUIStore from 'stores/AppUIStore';
 import UserAvatars from 'components/users/UserAvatars';
 import Icon from 'components/utilities/Icon';
 
-import SecretListItemFolderActions from './Actions';
+import SecretListItemActions from './Actions';
 
 const propTypes = {
   secret: PropTypes.any,
@@ -64,7 +64,7 @@ function SecretListItemFolder(props) {
           }
         </td>
         <td className="secret-list-item-last-actions">
-          <SecretListItemFolderActions secret={secret} />
+          <SecretListItemActions parentFolderId={folders.last()} secret={secret} />
         </td>
       </tr>
     )
@@ -81,7 +81,7 @@ const itemSource = {
 const itemTarget = {
   drop(props, monitor) {
     const { secret } = monitor.getItem();
-    MetadataActions.moveSecretToFolder({
+    MetadataActions.addSecretToFolder({
       secret,
       folder: props.secret,
     });

--- a/src/components/secrets/SecretListItem/Options.js
+++ b/src/components/secrets/SecretListItem/Options.js
@@ -12,7 +12,7 @@ const propTypes = {
   parentFolderId: PropTypes.string,
 };
 
-function SecretListItemActions({ parentFolderId, secret }) {
+function SecretListItemOptions({ parentFolderId, secret }) {
   const currentUser = AppUIStore.getCurrentUser();
   return (
     <Dropdown id="secret-action" pullRight>
@@ -39,7 +39,7 @@ function SecretListItemActions({ parentFolderId, secret }) {
             secret,
             currentFolderId: parentFolderId,
           })}
-          disabled={!secret.canBeUpdatedBy(currentUser) || typeof parentFolderId === 'undefined'}
+          disabled={!parentFolderId || !secret.canBeUpdatedBy(currentUser)}
         >
           Remove from this folder
         </Dropdown.MenuItem>
@@ -54,6 +54,6 @@ function SecretListItemActions({ parentFolderId, secret }) {
     </Dropdown>
   );
 }
-SecretListItemActions.propTypes = propTypes;
+SecretListItemOptions.propTypes = propTypes;
 
-export default SecretListItemActions;
+export default SecretListItemOptions;

--- a/src/components/secrets/SecretListItem/Secret.js
+++ b/src/components/secrets/SecretListItem/Secret.js
@@ -8,7 +8,7 @@ import UserAvatars from 'components/users/UserAvatars';
 
 import Icon from 'components/utilities/Icon';
 
-import SecretListItemActions from './Actions';
+import SecretListItemOptions from './Options';
 
 const propTypes = {
   secret: PropTypes.any,
@@ -60,7 +60,7 @@ function SecretListItemSecret({ secret, parentFolderId, isDragging, connectDragS
         }
       </td>
       <td className="secret-list-item-last-actions">
-        <SecretListItemActions parentFolderId={parentFolderId} secret={secret} />
+        <SecretListItemOptions parentFolderId={parentFolderId} secret={secret} />
       </td>
     </tr>
   );

--- a/src/components/secrets/SecretListItem/Secret.js
+++ b/src/components/secrets/SecretListItem/Secret.js
@@ -8,15 +8,16 @@ import UserAvatars from 'components/users/UserAvatars';
 
 import Icon from 'components/utilities/Icon';
 
-import SecretListItemFolderActions from './Actions';
+import SecretListItemActions from './Actions';
 
 const propTypes = {
   secret: PropTypes.any,
+  parentFolderId: PropTypes.string,
   isDragging: PropTypes.bool,
   connectDragSource: PropTypes.func.isRequired,
 };
 
-function SecretListItemSecret({ secret, isDragging, connectDragSource }) {
+function SecretListItemSecret({ secret, parentFolderId, isDragging, connectDragSource }) {
   const currentUser = AppUIStore.getCurrentUser();
   const users = secret.users.toList().filterNot(user => user.id === currentUser.username);
 
@@ -59,7 +60,7 @@ function SecretListItemSecret({ secret, isDragging, connectDragSource }) {
         }
       </td>
       <td className="secret-list-item-last-actions">
-        <SecretListItemFolderActions secret={secret} />
+        <SecretListItemActions parentFolderId={parentFolderId} secret={secret} />
       </td>
     </tr>
   );

--- a/src/components/secrets/SecretListItem/index.js
+++ b/src/components/secrets/SecretListItem/index.js
@@ -13,7 +13,7 @@ function SecretListItem({ secret, folders }) {
   if (secret.type === 'folder') {
     return <SecretListItemFolderFolder secret={secret} folders={folders} />;
   }
-  return <SecretListItemFolderSecret secret={secret} />;
+  return <SecretListItemFolderSecret parentFolderId={folders.last()} secret={secret} />;
 }
 SecretListItem.propTypes = propTypes;
 

--- a/src/stores/MetadataStore.js
+++ b/src/stores/MetadataStore.js
@@ -12,6 +12,12 @@ const MetadataState = new Record({
   metadata: new Immutable.Map(),
 });
 
+function buildSecrets(metadata) {
+  return Immutable.fromJS(metadata).map(
+    secret => Secret.createFromRaw(secret)
+  );
+}
+
 class MetadataStore {
   constructor() {
     this.bindAction(AppUIActions.LOGIN_USER_SUCCESS, this.onLoadMetadata);
@@ -20,27 +26,43 @@ class MetadataStore {
     this.state = new MetadataState();
   }
 
-  onLoadMetadata({ currentUser }) {
+  onLoadMetadata({ metadata }) {
     this.setState(this.state
-      .set('metadata', Immutable.fromJS(currentUser.metadatas).map(secret => Secret.createFromRaw(secret)))
+      .set('metadata', buildSecrets(metadata))
     );
   }
 
-  onCreateSecretSuccess({ currentUser }) {
+  onCreateSecretSuccess({ metadata }) {
     this.setState(this.state
-      .set('metadata', Immutable.fromJS(currentUser.metadatas).map(secret => Secret.createFromRaw(secret)))
+      .set('metadata', buildSecrets(metadata))
     );
   }
 
-  onDeleteSecretSuccess({ currentUser }) {
+  onDeleteSecretSuccess({ metadata }) {
     this.setState(this.state
-      .set('metadata', Immutable.fromJS(currentUser.metadatas).map(secret => Secret.createFromRaw(secret)))
+      .set('metadata', buildSecrets(metadata))
     );
   }
 
-  onDeleteSecretFailure({ currentUser }) {
+  onDeleteSecretFailure({ metadata }) {
     this.setState(this.state
-      .set('metadata', Immutable.fromJS(currentUser.metadatas).map(secret => Secret.createFromRaw(secret)))
+      .set('metadata', buildSecrets(metadata))
+    );
+  }
+
+  // onAddSecretToFolder({ secret, folder }) {
+  //  // TODO: Do something while we add the secret to a folder
+  // }
+
+  onAddSecretToFolderSuccess({ metadata }) {
+    this.setState(this.state
+      .set('metadata', buildSecrets(metadata))
+    );
+  }
+
+  onRemoveSecretFromCurrentFolderSuccess({ metadata }) {
+    this.setState(this.state
+      .set('metadata', buildSecrets(metadata))
     );
   }
 
@@ -70,22 +92,6 @@ class MetadataStore {
       .updateIn(['metadata', secret.id, 'users'], users =>
         users.filterNot(userToFilter => userToFilter.id === user.id)
       )
-    );
-  }
-
-  // onMoveSecretToFolder({ secret, folder }) {
-  //  // TODO: Do something while we move the secret
-  // }
-
-  onAddSecretToFolderSuccess({ metadata }) {
-    this.setState(this.state
-      .set('metadata', Immutable.fromJS(metadata).map(secret => Secret.createFromRaw(secret)))
-    );
-  }
-
-  onRemoveSecretFromCurrentFolderSuccess({ metadata }) {
-    this.setState(this.state
-      .set('metadata', Immutable.fromJS(metadata).map(secret => Secret.createFromRaw(secret)))
     );
   }
 

--- a/src/stores/MetadataStore.js
+++ b/src/stores/MetadataStore.js
@@ -38,6 +38,12 @@ class MetadataStore {
     );
   }
 
+  onDeleteSecretFailure({ currentUser }) {
+    this.setState(this.state
+      .set('metadata', Immutable.fromJS(currentUser.metadatas).map(secret => Secret.createFromRaw(secret)))
+    );
+  }
+
   onCreateSecretUserRightsSuccess({ secret, user, rights }) {
     this.setState(this.state
       .updateIn(['metadata', secret.id, 'users'], users =>
@@ -71,7 +77,13 @@ class MetadataStore {
   //  // TODO: Do something while we move the secret
   // }
 
-  onMoveSecretToFolderSuccess({ metadata }) {
+  onAddSecretToFolderSuccess({ metadata }) {
+    this.setState(this.state
+      .set('metadata', Immutable.fromJS(metadata).map(secret => Secret.createFromRaw(secret)))
+    );
+  }
+
+  onRemoveSecretFromCurrentFolderSuccess({ metadata }) {
     this.setState(this.state
       .set('metadata', Immutable.fromJS(metadata).map(secret => Secret.createFromRaw(secret)))
     );


### PR DESCRIPTION
Replace `moveSecretToFolder` by `addSecretToFolder` because move means deletion from the previous folder and would be a different action (done later).

New actions `removeFromCurrentFolder` was written to put back one secret/folder in ROOT directory and unshare it with everybody accessing the folder.