### PR TITLE
Upgrade electron dependencies to fix #64

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
   },
   "eslintConfig": {
     "extends": "./.eslintrc.js"
+  },
+  "resolutions": {
+    "electron-download": "4.1.0"
   }
 }

--- a/src/components/secrets/SecretListContent.js
+++ b/src/components/secrets/SecretListContent.js
@@ -48,10 +48,13 @@ class SecretListContent extends Component {
     if (this.props.filtered) {
       const allFolders = MetadataStore.getAllFolders();
       filteredSecrets.forEach(secret => {
-        const folderSeq = secret
+        let folderSeq = secret
           .getIn(['users', currentUser.username, 'folders'])
           .entrySeq()
           .first();
+        if (typeof folderSeq === 'undefined') {
+          folderSeq = ['ROOT'];
+        }
         filteredFolders = filteredFolders.setIn(
           [folderSeq[0], 'secrets', secret.id],
           secret


### PR DESCRIPTION
I'm facing the following issue :

```sh
...
[4/4] Building fresh packages...
error /usr/lib/secretin-app/node_modules/electron: Command failed.
Exit code: 1
Command: node install.js
Arguments:
Directory: /usr/lib/secretin-app/node_modules/electron
Output:
Downloading SHASUMS256.txt
[============================================>] 100.0% of 2.93 kB (2.93 kB/s)
/usr/lib/secretin-app/node_modules/electron/install.js:48
  throw err
  ^

Error: Generated checksum for "electron-v1.7.8-linux-x64.zip" did not match expected checksum.
    at ChecksumMismatchError.ErrorWithFilename (/usr/lib/secretin-app/node_modules/electron-download/node_modules/sumchecker/build.js:41:124)
    at new ChecksumMismatchError (/usr/lib/secretin-app/node_modules/electron-download/node_modules/sumchecker/build.js:56:133)
    at Hash.<anonymous> (/usr/lib/secretin-app/node_modules/electron-download/node_modules/sumchecker/build.js:203:22)
    at emitNone (events.js:105:13)
    at Hash.emit (events.js:207:7)
    at emitReadable_ (_stream_readable.js:516:10)
    at emitReadable (_stream_readable.js:510:7)
    at addChunk (_stream_readable.js:277:7)
    at readableAddChunk (_stream_readable.js:253:11)
    at Hash.Readable.push (_stream_readable.js:211:10)
```

I Googled and I found the following electron issue with a working solution. 

- [Electron issue #9595](https://github.com/electron/electron/issues/9595#issuecomment-391693101)

My two cents
