### PR TITLE
Upgrade react-scripts to fix #65

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node-sass": "^4.5.3",
     "prettier": "^1.5.3",
     "raw-loader": "^0.5.1",
-    "react-scripts": "1.0.10"
+    "react-scripts": "1.1.4"
   },
   "dependencies": {
     "alt": "^0.18.6",

--- a/src/components/secrets/SecretListContent.js
+++ b/src/components/secrets/SecretListContent.js
@@ -48,10 +48,13 @@ class SecretListContent extends Component {
     if (this.props.filtered) {
       const allFolders = MetadataStore.getAllFolders();
       filteredSecrets.forEach(secret => {
-        const folderSeq = secret
+        let folderSeq = secret
           .getIn(['users', currentUser.username, 'folders'])
           .entrySeq()
           .first();
+        if (typeof folderSeq === 'undefined') {
+          folderSeq = ['ROOT'];
+        }
         filteredFolders = filteredFolders.setIn(
           [folderSeq[0], 'secrets', secret.id],
           secret


### PR DESCRIPTION
I'm facing the following issue while building application

```sh
$ yarn run build-css && NODE_PATH=./src node_modules/.bin/react-scripts build
Rendering Complete, saving .css file...
Wrote CSS to /usr/lib/secretin-app/src/index.css
Creating an optimized production build...
Failed to compile.

./src/components/App.js
  Line 18:  'propTypes' is not defined  no-undef

Search for the keywords to learn more about each error.

error Command failed with exit code 1.
```

I found out that upgrading `react-scripts` to latest version solve the problem.

After `react-script` upgrade:
```sh
$ yarn run build-css && NODE_PATH=./src node_modules/.bin/react-scripts build
Rendering Complete, saving .css file...
Wrote CSS to /usr/lib/secretin-app/src/index.css
Creating an optimized production build...
Compiled successfully.

File sizes after gzip:

  214.84 KB  build/static/js/main.9161ccd0.js
  4.5 KB     build/static/css/main.3dc3bc02.css

The project was built assuming it is hosted at https://secret-in.me.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  yarn global add serve
  serve -s build

Find out more about deployment here:

  http://bit.ly/2vY88Kr

Done in 21.94s.
```