### PR TITLE
fix(app): handle secrets with null title

### DIFF
--- a/src/components/secrets/SecretListContent.js
+++ b/src/components/secrets/SecretListContent.js
@@ -104,9 +104,11 @@ class SecretListContent extends Component {
         })
         .flat();
     } else {
-      filteredSecrets.sort((a, b) =>
-        a.title.toLowerCase().localeCompare(b.title.toLowerCase())
-      );
+      filteredSecrets.sort((a, b) => {
+        if (a.title === null) return 1;
+        if (b.title === null) return -1;
+        return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
+      });
     }
 
     const renderFilteredRow = ({ index, key, style }) => {


### PR DESCRIPTION
Can't reproduce the bug but based on screenshots of the error, it seems the crash comes from those lines. We're already doing this check for secrets within folders so I just duplicated the behaviour for all secrets.